### PR TITLE
Bundle httpmime dependency too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Release Notes
 ===
 
+# 4.5.3-2.0
+
+* Bundle all components of HttpComponents Client 4.5.x instead of just the core client library
+
 # 4.5.3-1.0
 
 Release date: Aug 15, 2017

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Apache HttpComponents Client 4.x API Plugin for Jenkins
 ===
 
-This plugin bundles the [Apache HttpComponents Client 4.5.x](https://hc.apache.org/httpcomponents-client-4.5.x/index.html) library,
-which can be used by other plugins as a dependency.
+This plugin bundles all the components of [Apache HttpComponents Client 4.5.x](https://hc.apache.org/httpcomponents-client-4.5.x/index.html) except `httpclient-win` because of the dependency on jna.
+These components can be used by other plugins as a dependency.
 It allows managing library updates independently from plugins.
 
 ## Release Notes

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,16 @@
       <artifactId>httpmime</artifactId>
       <version>${httpclient.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>fluent-hc</artifactId>
+      <version>${httpclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient-cache</artifactId>
+      <version>${httpclient.version}</version>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
   <properties>
     <jenkins.version>1.625.3</jenkins.version>
     <java.level>7</java.level>
+    <httpclient.version>4.5.3</httpclient.version>
   </properties>
 
   <name>Jenkins Apache HttpComponents Client 4.x API Plugin</name>
@@ -47,7 +48,12 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.3</version>
+      <version>${httpclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpmime</artifactId>
+      <version>${httpclient.version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
MIME handling has been extracted in a separate library in HC 4.X (though 
it shares the same git repository). It is required to create multipart
entities for POST requests. It'll be used pretty often.

@oleg-nenashev 