### PR TITLE
Fix error thrown when connecting over https when the certificate contains a SAN 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
   </parent>
   
   <artifactId>apache-httpcomponents-client-4-api</artifactId>
-  <version>4.5.3-3.1-SNAPSHOT</version>
+  <version>4.5.5-3.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <properties>
     <jenkins.version>1.625.3</jenkins.version>
     <java.level>7</java.level>
-    <httpclient.version>4.5.3</httpclient.version>
+    <httpclient.version>4.5.5</httpclient.version>
   </properties>
 
   <name>Jenkins Apache HttpComponents Client 4.x API Plugin</name>


### PR DESCRIPTION
Httpclient 4.5.3 is unable to connect over https if the certificate has an Subject Alternative Name field.

This PR resolves that issue by updating to latest upstream release in the 4.5 series. 