### PR TITLE
Bundle HttpAsyncClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <jenkins.version>1.625.3</jenkins.version>
     <java.level>7</java.level>
     <httpclient.version>4.5.5</httpclient.version>
+    <httpasyncclient.version>4.1.3</httpasyncclient.version>
   </properties>
 
   <name>Jenkins Apache HttpComponents Client 4.x API Plugin</name>
@@ -70,6 +71,16 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-cache</artifactId>
       <version>${httpclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpasyncclient</artifactId>
+      <version>${httpasyncclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpasyncclient-cache</artifactId>
+      <version>${httpasyncclient.version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
As a shared library wrapper plugin, it's feasible to bundle all tightly coupled dependencies.
