### PR TITLE
[JENKINS-59172] - Use GitHub as a source of the plugin's documentation on plugins.jenkins.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <name>Jenkins Apache HttpComponents Client 4.x API Plugin</name>
   <description>Bundles Apache HttpComponents Client 4.x and allows it to be used by Jenkins plugins</description>
-  <url>https://wiki.jenkins.io/display/JENKINS/Apache+HttpComponents+Client+4.x+API+Plugin</url>
+  <url>https://github.com/jenkinsci/apache-httpcomponents-client-4-api-plugin</url>
 
   <licenses>
     <license>


### PR DESCRIPTION
GitHub plugin README may look empty, but the Wiki page is just a stub pointing to GitHub.
FTR https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A
