### PR TITLE
Make RobustHTTPClient a public API (was in Beta before)

### DIFF
--- a/src/main/java/io/jenkins/plugins/httpclient/RobustHTTPClient.java
+++ b/src/main/java/io/jenkins/plugins/httpclient/RobustHTTPClient.java
@@ -58,13 +58,10 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.FileEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.Beta;
 
 /**
  * Utility to make HTTP connections with protection against transient failures.
  */
-@Restricted(Beta.class)
 public final class RobustHTTPClient implements Serializable {
 
     private static final long serialVersionUID = 1;


### PR DESCRIPTION
Similarly to https://github.com/jenkinsci/workflow-api-plugin/pull/108. Note that #24 proposes an API change, but it is minor and easy to keep compatible. Downstreams in

- [x] `artifact-manager-s3`
- [ ] ~`workflow-basic-steps`~ (would also need to unrestrict `VirtualFile.toExternalURL`, which seems fine, waiting for a core update, but…)
- [ ] ~`copyartifact`~ (also uses `VirtualFile.toExternalURL` and `.list`, fine, but then also `.readLink` and `mode` which we _might_ want to deprecate in favor of not storing filesystem exotica in artifacts)