### PR TITLE
added explicit dependency to httpcore(-nio)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
+    <httpcore.version>4.4.13</httpcore.version>
     <httpclient.version>4.5.12</httpclient.version>
     <httpasyncclient.version>4.1.4</httpasyncclient.version>
   </properties>
@@ -48,6 +49,16 @@
   </scm>
 
   <dependencies>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <version>${httpcore.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore-nio</artifactId>
+      <version>${httpcore.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>


### PR DESCRIPTION
I'm trying to tidy the dependencies management on a plugin which has several (indirect) dependencies on various httpcomponents librairies. Most of the upper-bound issues (for httpcomponents) can be successfully solved by following [instructions from the README](https://github.com/jenkinsci/apache-httpcomponents-client-4-api-plugin/blob/master/README.md#plugins-using-libraries-depending-on-httpclient) (adding a dependency on `apache-httpcomponents-client-4-api` before the other involved dependencies).

But I'm still facing this error, for `httpcore` (because there is no direct `httpcore` dependency in `apache-httpcomponents-client-4-api`):
```
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for org.apache.httpcomponents:httpcore:4.4.1 paths to dependency are:
+-org.jenkins-ci.plugins:artifactory:3.8.x-SNAPSHOT
  +-org.jfrog.artifactory.client:artifactory-java-client-services:2.6.2
    +-org.apache.httpcomponents:httpcore:4.4.1
and
+-org.jenkins-ci.plugins:artifactory:3.8.x-SNAPSHOT
  +-org.jenkins-ci.plugins:apache-httpcomponents-client-4-api:4.5.10-2.0
    +-org.apache.httpcomponents:httpclient:4.5.10
      +-org.apache.httpcomponents:httpcore:4.4.1
and
+-org.jenkins-ci.plugins:artifactory:3.8.x-SNAPSHOT
  +-org.jenkins-ci.plugins:apache-httpcomponents-client-4-api:4.5.10-2.0
    +-org.apache.httpcomponents:httpasyncclient:4.1.4
      +-org.apache.httpcomponents:httpcore:4.4.10
and
+-org.jenkins-ci.plugins:artifactory:3.8.x-SNAPSHOT
  +-org.jfrog.buildinfo:build-info-extractor-docker:2.19.2
    +-com.github.docker-java:docker-java:3.1.2
      +-org.apache.httpcomponents:httpcore:4.4.10
and
+-org.jenkins-ci.plugins:artifactory:3.8.x-SNAPSHOT
  +-org.jfrog.artifactory.client:artifactory-java-client-services:2.6.2
    +-org.jfrog.artifactory.client:artifactory-java-client-api:2.6.2
      +-org.apache.httpcomponents:httpcore:4.4.1
and
+-org.jenkins-ci.plugins:artifactory:3.8.x-SNAPSHOT
  +-org.jfrog.artifactory.client:artifactory-java-client-services:2.6.2
    +-org.jfrog.artifactory.client:artifactory-java-client-httpClient:2.6.2
      +-org.apache.httpcomponents:httpcore:4.4.1
and
+-org.jenkins-ci.plugins:artifactory:3.8.x-SNAPSHOT
  +-org.jenkins-ci.plugins:apache-httpcomponents-client-4-api:4.5.10-2.0
    +-org.apache.httpcomponents:httpasyncclient:4.1.4
      +-org.apache.httpcomponents:httpcore-nio:4.4.10
        +-org.apache.httpcomponents:httpcore:4.4.10
]
```

One option would be to manage the `httpcore` version explicitly (in the plugin I'm modifying), but I'd rather avoid that, it could become error prone in the future (if `apache-httpcomponents-client-4-api` gets upgraded without also bumping the `httpcore` version to whatever would then become required).
So I propose to add an explicit direct dependency on `httpcore` in `apache-httpcomponents-client-4-api` itself. And also to add `httpcore-nio`, so that it is kept in sync. Both libs are already (indirectly) depended-on anyway, so it can't really hurt. And I've tested (with a local release) that this change indeed makes maven-enforcer happy in my case.