### PR TITLE
Enable jdk11 build on CI for linux and windows

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,6 @@
 // Builds a module using https://github.com/jenkins-infra/pipeline-library
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
-
+buildPlugin(configurations: [
+    [platform: 'linux', jdk: '8'],
+    [platform: 'linux', jdk: '11'],
+    [platform: 'windows', jdk: '11'],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -5,10 +5,10 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.57</version>
+    <version>4.33</version>
     <relativePath />
   </parent>
-  
+
   <artifactId>apache-httpcomponents-client-4-api</artifactId>
   <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
@@ -16,7 +16,7 @@
   <properties>
     <revision>4.5.13-2.0</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.60.3</jenkins.version>
+    <jenkins.version>2.277.4</jenkins.version>
     <java.level>8</java.level>
     <httpcore.version>4.4.14</httpcore.version>
     <httpclient.version>4.5.13</httpclient.version>
@@ -47,7 +47,17 @@
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <tag>${scmTag}</tag>
   </scm>
-
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.277.x</artifactId>
+        <version>961.vf0c9f6f59827</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -115,8 +125,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
-        
+
         <!-- Consider adding to Jenkins plugin parent POM? -->
         <dependencies>
           <dependency>


### PR DESCRIPTION
Refile of https://github.com/jenkinsci/apache-httpcomponents-client-4-api-plugin/pull/68 as a maintainer for the Jenkinsfile to be actually used.