### PR TITLE
Fix javadoc warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,13 @@
       <artifactId>httpasyncclient-cache</artifactId>
       <version>${httpasyncclient.version}</version>
     </dependency>
+    <!-- spotbugs annotations needed to suppress javadoc warning -->
+    <!-- warning: unknown enum constant When.ALWAYS -->
+    <!-- reason: class file for javax.annotation.meta.When not found -->
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+    </dependency>
   </dependencies>
 
   <repositories>


### PR DESCRIPTION
## Fix javadoc warning

The javadoc warning is

```
warning: unknown enum constant When.ALWAYS
reason: class file for javax.annotation.meta.When not found
```

The [stackoverflow article](https://stackoverflow.com/questions/53326271/spring-nullable-annotation-generates-unknown-enum-constant-warning) notes that the warning happens when annotation symbols for spotbugs are not available.

This adds two new components to the packaged plugin, the spotbugs annotation jar file and a jsr-305 jar file.

@jglick is it OK that other jar files (like the spotbugs annotation jar file) are included in an API plugin like this or is it better than I accept the javadoc warning rather than adding more components to the plugin?

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
