### PR TITLE
Avoid wildcard imports, even in tests

### DIFF
--- a/src/test/java/io/jenkins/plugins/httpclient/RobustHTTPClientIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/httpclient/RobustHTTPClientIntegrationTest.java
@@ -23,8 +23,9 @@
  */
 package io.jenkins.plugins.httpclient;
 
-import static org.hamcrest.MatcherAssert.*;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertThrows;
 
 import hudson.AbortException;

--- a/src/test/java/io/jenkins/plugins/httpclient/RobustHTTPClientTest.java
+++ b/src/test/java/io/jenkins/plugins/httpclient/RobustHTTPClientTest.java
@@ -24,8 +24,9 @@
 
 package io.jenkins.plugins.httpclient;
 
-import static org.hamcrest.MatcherAssert.*;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 
 import java.net.URL;


### PR DESCRIPTION
## Avoid wildcard imports, even in tests

Changes from 2 import statements to 3 import statements.  That's not too intrusive to the reader.

[Use hamcrest assertThat, not junit assertThat](https://docs.openrewrite.org/recipes/java/testing/junit5/usehamcrestassertthat) is the original catalyst for this change.  The OpenRewrite command line generated the initial changes, then I extended them for further simplification.

### Testing done

Confirmed that tests pass on Linux

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
