### PR TITLE
Use jenkins.baseline property to avoid BOM update mistakes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,8 @@
     <revision>4.5.14</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.401.3</jenkins.version>
+    <jenkins.baseline>2.401</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <httpcore.version>4.4.16</httpcore.version>
     <httpclient.version>${revision}</httpclient.version>
     <httpasyncclient.version>4.1.5</httpasyncclient.version>
@@ -58,7 +59,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.401.x</artifactId>
+        <artifactId>bom-${jenkins.baseline}.x</artifactId>
         <version>2745.vc7b_fe4c876fa_</version>
         <type>pom</type>
         <scope>import</scope>


### PR DESCRIPTION
## Use jenkins.baseline property to avoid BOM update mistakes

Avoid updates to jenkins.version that do not also update the Jenkins plugin bill of materials version.

Inspired by:

* https://github.com/jenkinsci/archetypes/pull/737

### Testing done

Confirmed that `mvn help:effective-pom` after the change matches expected values.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
