### PR TITLE
Fix test for newer Jenkins versions

### DIFF
--- a/src/test/java/io/jenkins/plugins/httpclient/RobustHTTPClientIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/httpclient/RobustHTTPClientIntegrationTest.java
@@ -67,7 +67,8 @@ public class RobustHTTPClientIntegrationTest {
     @Test
     public void testDownloadFile() throws Exception {
         client.downloadFile(f, j.getURL(), TaskListener.NULL);
-        assertThat(Files.readString(f.toPath()), containsString("<title>Dashboard [Jenkins]</title>"));
+        // Jenkins controller root page should always contain at lease one reference to Jenkins web site
+        assertThat(Files.readString(f.toPath()), containsString("https://www.jenkins.io/"));
     }
 
     /**


### PR DESCRIPTION
## Fix test for newer Jenkins versions

Dashboard string is not always included in the root page of the Jenkins controller, nor should the test require that it is included.  It is enough to check that the page contains the well-known URL of the Jenkins website.

### Testing done

Confirmed that before this change the test fails with:

```
mvn clean -Djenkins.version=2.496 verify
```

Confirmed that the test passes after the change.

Confirmed that the test passes before and after this change with the command:

```
mvn clean verify
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
